### PR TITLE
Cicd/package bundle javascript

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ parameters:
     description: "What is the version number of the release you want to replay? (Mandatory, only for the 'standalone_release_replay' Workflow / see 'gio_action' pipeline parameter)"
 orbs:
   slack: circleci/slack@4.2.1
+  apim: gravitee-io/gravitee-apim@dev:1.0.3
   gravitee: gravitee-io/gravitee@1.0
   # gravitee: gravitee-io/gravitee@dev:1.0.4
   secrethub: secrethub/cli@1.1.0
@@ -165,6 +166,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - apim/d_javascript_package_bundle:
+          requires:
+            - maven_n_git_release
+          dry_run: false
 
   standalone_release_dry_run:
     when:
@@ -186,6 +191,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - apim/d_javascript_package_bundle:
+          requires:
+            - maven_n_git_release
+          dry_run: true
 
   standalone_nexus_staging:
     # ---
@@ -261,6 +270,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - apim/d_javascript_package_bundle:
+          requires:
+            - maven_n_git_release
+          dry_run: false
 
   standalone_release_replay_dry_run:
     when:
@@ -283,6 +296,10 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+      - apim/d_javascript_package_bundle:
+          requires:
+            - maven_n_git_release
+          dry_run: true
 
   standalone_nexus_staging_replay:
     # ---


### PR DESCRIPTION
here below the CircleCI Pipeline link : it launches the workflow "standalone_release_replay_dry_run" in dry-run mode, the newly added/modified job in this pipeline is "d_javascript_package_bundle" in order to publish the zip files in the download.gravitee

CCI link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-am-identityprovider-cas/10/workflows/daad16b2-2fbc-4364-9a23-f5e52eed6e40/jobs/20

S3 bucket link : https://gravitee-dry-releases-downloads.cellar-c2.services.clever-cloud.com/index.html#graviteeio-apim/plugins/policies/gravitee-policy-javascript/

Link to the slab documentation : https://gravitee.slab.com/posts/the-gravitee-policy-javascript-71w885gh