### PR TITLE
fix: allow error on request and response content phases

### DIFF
--- a/src/main/java/io/gravitee/policy/javascript/JavascriptPolicy.java
+++ b/src/main/java/io/gravitee/policy/javascript/JavascriptPolicy.java
@@ -243,13 +243,13 @@ public class JavascriptPolicy {
         // And run script
         try {
             content = eval(script, scriptContext);
-
-            if (result.getState() == PolicyResult.State.FAILURE) {
-                throw new PolicyFailureException(result);
-            }
         } catch (Exception e) {
             result.setState(PolicyResult.State.FAILURE);
             result.setError(e.getMessage());
+            throw new PolicyFailureException(result);
+        }
+
+        if (result.getState() == PolicyResult.State.FAILURE) {
             throw new PolicyFailureException(result);
         }
 

--- a/src/test/resources/io/gravitee/policy/javascript/break_request_content.js
+++ b/src/test/resources/io/gravitee/policy/javascript/break_request_content.js
@@ -1,0 +1,9 @@
+if (request.headers.containsKey('X-Gravitee-Break')) {
+    result.state = State.FAILURE
+    result.code = 500
+    result.error = 'Stop request content processing due to X-Gravitee-Break header'
+} else {
+    request.headers.set('X-Groovy-Policy', 'ok');
+}
+
+request.content


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7173

**Description**

See issue
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-SNAPSHOT.7173-allow-error-on-content-phases`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-javascript/1.1.1-SNAPSHOT.7173-allow-error-on-content-phases/gravitee-policy-javascript-1.1.1-SNAPSHOT.7173-allow-error-on-content-phases.zip)
  <!-- Version placeholder end -->
