### PR TITLE
Fix `scheme` and add methods to get `host`, `getMetrics` and `attributes` 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -122,6 +122,20 @@ JSON.stringify(content);
 ]
 ----
 
+=== Dictionaries - Properties
+
+Both Dictionaries (defined at the environment level) and Properties (defined at the API level) can be accessed from the JavaScript script, using:
+
+ - `context.dictionaries()` for Dictionaries
+ - `context.properties()` for Properties
+
+Here is an example of how to set a request header based on a Property:
+
+[source,javascript]
+----
+request.headers.set('X-JavaScript-Policy', context.properties()['KEY_OF_MY_PROPERTY']);
+----
+
 == Errors
 
 === HTTP status code

--- a/src/main/java/io/gravitee/policy/javascript/model/js/JsExecutionContext.java
+++ b/src/main/java/io/gravitee/policy/javascript/model/js/JsExecutionContext.java
@@ -25,16 +25,29 @@ import java.util.Map;
 public class JsExecutionContext {
 
     private static final String CONTEXT_DICTIONARIES_VARIABLE = "dictionaries";
+    private static final String CONTEXT_PROPERTIES_VARIABLE = "properties";
     private final ExecutionContext context;
 
     public JsExecutionContext(final ExecutionContext context) {
         this.context = context;
     }
 
-    public Map<String, Map<String, String>> getDictionaries() {
+    public Map<String, Map<String, String>> dictionaries() {
         return (Map<String, Map<String, String>>) this.context.getTemplateEngine()
             .getTemplateContext()
             .lookupVariable(CONTEXT_DICTIONARIES_VARIABLE);
+    }
+
+    public Map<String, Map<String, String>> getDictionaries() {
+        return this.dictionaries();
+    }
+
+    public Map<String, String> properties() {
+        return (Map<String, String>) this.context.getTemplateEngine().getTemplateContext().lookupVariable(CONTEXT_PROPERTIES_VARIABLE);
+    }
+
+    public Map<String, String> getProperties() {
+        return this.properties();
     }
 
     public void attribute(String s, Object o) {

--- a/src/main/java/io/gravitee/policy/javascript/model/js/JsRequest.java
+++ b/src/main/java/io/gravitee/policy/javascript/model/js/JsRequest.java
@@ -150,7 +150,7 @@ public class JsRequest {
     }
 
     public String scheme() {
-        return request.localAddress();
+        return request.scheme();
     }
 
     public String getScheme() {

--- a/src/main/java/io/gravitee/policy/javascript/model/js/JsRequest.java
+++ b/src/main/java/io/gravitee/policy/javascript/model/js/JsRequest.java
@@ -168,4 +168,12 @@ public class JsRequest {
     public Metrics metrics() {
         return request.metrics();
     }
+
+    public String host() {
+        return request.host();
+    }
+
+    public String getHost() {
+        return this.host();
+    }
 }

--- a/src/main/java/io/gravitee/policy/javascript/model/js/JsRequest.java
+++ b/src/main/java/io/gravitee/policy/javascript/model/js/JsRequest.java
@@ -169,6 +169,10 @@ public class JsRequest {
         return request.metrics();
     }
 
+    public Metrics getMetrics() {
+        return this.metrics();
+    }
+
     public String host() {
         return request.host();
     }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1455

**Description**

Fix `scheme` and add methods to get `host`, `getMetrics` and `attributes` 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.0-improve-request-info-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-javascript/1.2.0-improve-request-info-SNAPSHOT/gravitee-policy-javascript-1.2.0-improve-request-info-SNAPSHOT.zip)
  <!-- Version placeholder end -->
