### PR TITLE
Protect the engine property from being deleted

### DIFF
--- a/src/main/java/io/gravitee/policy/javascript/JavascriptPolicy.java
+++ b/src/main/java/io/gravitee/policy/javascript/JavascriptPolicy.java
@@ -257,6 +257,9 @@ public class JavascriptPolicy {
     }
 
     private String eval(String script, ScriptContext scriptContext) throws ScriptException, ExecutionException, InterruptedException {
+        // As per https://github.com/javadelight/delight-nashorn-sandbox/issues/73
+        JAVASCRIPT_ENGINE.eval("Object.defineProperty(this, 'engine', {});\n" + "Object.defineProperty(this, 'context', {});");
+        JAVASCRIPT_ENGINE.eval("delete this.__noSuchProperty__;");
         Object ret = JAVASCRIPT_ENGINE.eval(script, scriptContext);
 
         final JsHttpClient httpClient = (JsHttpClient) scriptContext.getAttribute("httpClient");

--- a/src/test/java/io/gravitee/policy/javascript/JavascriptPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/javascript/JavascriptPolicyTest.java
@@ -319,6 +319,13 @@ public class JavascriptPolicyTest {
         fail("a should be undefined and it should raise an ScriptException");
     }
 
+    @Test(expected = ScriptException.class)
+    public void engineNotAllowed() throws ScriptException {
+        String script =
+            "delete this.engine; this.engine.factory.scriptEngine.compile('var Run = Java.type(\\\"java.lang.Runtime\\\"); Run.getRuntime().exec(\\\"curl http://localhost:8082/\\\");').eval()";
+        JAVASCRIPT_ENGINE.eval(script);
+    }
+
     private String loadResource(String resource) throws IOException {
         InputStream stream = JavascriptPolicy.class.getResourceAsStream(resource);
         return readInputStreamToString(stream, Charset.defaultCharset());


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2073

**Description**

As per https://github.com/javadelight/delight-nashorn-sandbox/issues/73 , the engine property is now effectively unmodifiable.
