### PR TITLE
fix(engine): Protect the engine property from being deleted

### DIFF
--- a/src/main/java/io/gravitee/policy/javascript/JavascriptInitializer.java
+++ b/src/main/java/io/gravitee/policy/javascript/JavascriptInitializer.java
@@ -24,6 +24,7 @@ import io.vertx.core.http.HttpClientOptions;
 import javax.script.Bindings;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
+import javax.script.ScriptException;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
 /**
@@ -72,6 +73,14 @@ public class JavascriptInitializer implements PolicyContext, PolicyContextProvid
             bd.remove("exit");
             bd.remove("eval");
             bd.remove("quit");
+
+            // As per https://github.com/javadelight/delight-nashorn-sandbox/issues/73
+            try {
+                JAVASCRIPT_ENGINE.eval("Object.defineProperty(this, 'engine', {});\n" + "Object.defineProperty(this, 'context', {});");
+                JAVASCRIPT_ENGINE.eval("delete this.__noSuchProperty__;");
+            } catch (ScriptException e) {
+                throw new RuntimeException(e);
+            }
 
             initHttpClient();
             initialized = true;

--- a/src/test/java/io/gravitee/policy/javascript/JavascriptPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/javascript/JavascriptPolicyTest.java
@@ -319,6 +319,13 @@ public class JavascriptPolicyTest {
         fail("a should be undefined and it should raise an ScriptException");
     }
 
+    @Test(expected = ScriptException.class)
+    public void engineNotAllowed() throws ScriptException {
+        String script =
+            "delete this.engine; this.engine.factory.scriptEngine.compile('var Run = Java.type(\\\"java.lang.Runtime\\\"); Run.getRuntime().exec(\\\"curl http://localhost:8082/\\\");').eval()";
+        JAVASCRIPT_ENGINE.eval(script);
+    }
+
     private String loadResource(String resource) throws IOException {
         InputStream stream = JavascriptPolicy.class.getResourceAsStream(resource);
         return readInputStreamToString(stream, Charset.defaultCharset());


### PR DESCRIPTION
Issue

https://gravitee.atlassian.net/browse/APIM-2073

Description

As per https://github.com/javadelight/delight-nashorn-sandbox/issues/73 , the engine property is now effectively unmodifiable.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.2.1-APIM-2073-sandbox-escape-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-javascript/1.2.1-APIM-2073-sandbox-escape-SNAPSHOT/gravitee-policy-javascript-1.2.1-APIM-2073-sandbox-escape-SNAPSHOT.zip)
  <!-- Version placeholder end -->
