### PR TITLE
feat: allow to add response template key in policy result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,15 +30,16 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.0</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-gateway-buffer.version>1.18.3</gravitee-gateway-buffer.version>
-        <gravitee-policy-api.version>1.9.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.17.2</gravitee-common.version>
+        <gravitee-bom.version>3.0.8</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
+        <gravitee-apim.version>3.18.28</gravitee-apim.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-expression-language.version>1.9.7</gravitee-expression-language.version>
         <javascript.version>2.5.14</javascript.version>
         <javascript-sandbox.version>1.27</javascript-sandbox.version>
         <commons-lang3.version>3.11</commons-lang3.version>
@@ -112,6 +113,20 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+            <version>${gravitee-expression-language.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
@@ -144,9 +159,9 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.gateway</groupId>
-            <artifactId>gravitee-gateway-buffer</artifactId>
-            <version>${gravitee-gateway-buffer.version}</version>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/javascript/JavascriptPolicy.java
+++ b/src/main/java/io/gravitee/policy/javascript/JavascriptPolicy.java
@@ -100,6 +100,7 @@ public class JavascriptPolicy {
                             if (ex.getResult().getContentType() != null) {
                                 policyChain.streamFailWith(
                                     io.gravitee.policy.api.PolicyResult.failure(
+                                        ex.getResult().getKey(),
                                         ex.getResult().getCode(),
                                         ex.getResult().getError(),
                                         ex.getResult().getContentType()
@@ -107,7 +108,11 @@ public class JavascriptPolicy {
                                 );
                             } else {
                                 policyChain.streamFailWith(
-                                    io.gravitee.policy.api.PolicyResult.failure(ex.getResult().getCode(), ex.getResult().getError())
+                                    io.gravitee.policy.api.PolicyResult.failure(
+                                        ex.getResult().getKey(),
+                                        ex.getResult().getCode(),
+                                        ex.getResult().getError()
+                                    )
                                 );
                             }
                         } catch (Throwable t) {
@@ -151,6 +156,7 @@ public class JavascriptPolicy {
                             if (ex.getResult().getContentType() != null) {
                                 policyChain.streamFailWith(
                                     io.gravitee.policy.api.PolicyResult.failure(
+                                        ex.getResult().getKey(),
                                         ex.getResult().getCode(),
                                         ex.getResult().getError(),
                                         ex.getResult().getContentType()
@@ -158,7 +164,11 @@ public class JavascriptPolicy {
                                 );
                             } else {
                                 policyChain.streamFailWith(
-                                    io.gravitee.policy.api.PolicyResult.failure(ex.getResult().getCode(), ex.getResult().getError())
+                                    io.gravitee.policy.api.PolicyResult.failure(
+                                        ex.getResult().getKey(),
+                                        ex.getResult().getCode(),
+                                        ex.getResult().getError()
+                                    )
                                 );
                             }
                         } catch (Throwable t) {
@@ -215,13 +225,16 @@ public class JavascriptPolicy {
                                 if (result.getContentType() != null) {
                                     policyChain.failWith(
                                         io.gravitee.policy.api.PolicyResult.failure(
+                                            result.getKey(),
                                             result.getCode(),
                                             result.getError(),
                                             result.getContentType()
                                         )
                                     );
                                 } else {
-                                    policyChain.failWith(io.gravitee.policy.api.PolicyResult.failure(result.getCode(), result.getError()));
+                                    policyChain.failWith(
+                                        io.gravitee.policy.api.PolicyResult.failure(result.getKey(), result.getCode(), result.getError())
+                                    );
                                 }
                             }
                         }

--- a/src/main/java/io/gravitee/policy/javascript/PolicyResult.java
+++ b/src/main/java/io/gravitee/policy/javascript/PolicyResult.java
@@ -31,6 +31,16 @@ public class PolicyResult {
 
     private String contentType = null;
 
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
     public String getError() {
         return error;
     }

--- a/src/test/java/io/gravitee/policy/javascript/JavascriptPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/javascript/JavascriptPolicyIntegrationTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.javascript;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.policy.javascript.configuration.JavascriptPolicyConfiguration;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class JavascriptPolicyIntegrationTest extends AbstractPolicyTest<JavascriptPolicy, JavascriptPolicyConfiguration> {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
+    }
+
+    /**
+     * Override api plans to have a published API_KEY one.
+     * @param api is the api to apply this function code
+     */
+    @Override
+    public void configureApi(Api api) {
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+
+    @Test
+    @DeployApi("/apis/api.json")
+    void should_execute_script(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("").withHeader("X-To-Remove", "value")));
+
+        client
+            .post("/test")
+            .rxSend()
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(response.headers().names()).doesNotContain("X-To-Remove");
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo("/team")).withHeader("X-Gravitee-Javascript", equalTo("Yes")));
+    }
+
+    @Test
+    @DeployApi("/apis/api-fail-response-template-no-key.json")
+    void should_not_use_response_template_when_no_key_provided(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("")));
+
+        client
+            .post("/test")
+            .putHeader(HttpHeaderNames.ACCEPT.toString(), "*/*")
+            .putHeader("X-Gravitee-Break", "break")
+            .rxSend()
+            .map(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(409);
+                    assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE)).isNotNull().isEqualTo("application/json");
+                    return response.body();
+                }
+            )
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(
+                body -> {
+                    assertThat(body).hasToString("{\"message\":\"Error message no response template\",\"http_status_code\":409}");
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+
+        wiremock.verify(0, postRequestedFor(urlPathEqualTo("/team")));
+    }
+
+    @Test
+    @DeployApi("/apis/api-fail-response-template.json")
+    void should_use_response_template_when_key_provided(WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok("")));
+
+        client
+            .post("/test")
+            .putHeader(HttpHeaderNames.ACCEPT.toString(), "*/*")
+            .putHeader("X-Gravitee-Break", "break")
+            .rxSend()
+            .map(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(450);
+                    assertThat(response.headers().get(HttpHeaderNames.CONTENT_TYPE)).isNotNull().isEqualTo("application/xml");
+                    return response.body();
+                }
+            )
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(
+                body -> {
+                    assertThat(body)
+                        .hasToString(
+                            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<auth>\n    <resp>\n        <hdr>E</hdr>\n        <errDesc>internal technical error </errDesc>\n    </resp>\n</auth>"
+                        );
+                    return true;
+                }
+            )
+            .assertComplete()
+            .assertNoErrors();
+
+        wiremock.verify(0, postRequestedFor(urlPathEqualTo("/team")));
+    }
+}

--- a/src/test/resources/apis/api-fail-response-template-no-key.json
+++ b/src/test/resources/apis/api-fail-response-template-no-key.json
@@ -1,0 +1,55 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Javascript",
+          "description": "",
+          "enabled": true,
+          "policy": "javascript",
+          "configuration": {
+            "onRequestScript": "if (request.headers.containsKey('X-Gravitee-Break')) {\n response.headers.set('X-Javascript-Policy', 'ko');\n result.state = State.FAILURE;\n result.code = 409;\n result.error = 'Error message no response template';\n result.contentType = 'application/xml';\n } else {\n response.headers.set('X-Javascript-Policy','ok');\n }"
+          }
+        }
+      ],
+      "post": [
+      ]
+    }
+  ],
+  "resources": [],
+  "response_templates": {
+    "DEFAULT" : {
+      "*/*" : {
+        "status" : 450,
+        "headers" : {
+          "Content-Type" : "application/xml"
+        },
+        "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<auth>\n    <resp>\n        <hdr>E</hdr>\n        <errDesc>internal technical error </errDesc>\n    </resp>\n</auth>"
+      }
+    }
+  }
+}

--- a/src/test/resources/apis/api-fail-response-template.json
+++ b/src/test/resources/apis/api-fail-response-template.json
@@ -1,0 +1,55 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Javascript",
+          "description": "",
+          "enabled": true,
+          "policy": "javascript",
+          "configuration": {
+            "onRequestScript": "if (request.headers.containsKey('X-Gravitee-Break')) {\n response.headers.set('X-Javascript-Policy', 'ko');\n result.state = State.FAILURE;\n result.code = 500;\n result.key = 'DEFAULT';\n result.error = 'Error message';\n result.contentType = 'application/xml';\n } else {\n response.headers.set('X-Groovy-Policy', 'ok');\n }"
+          }
+        }
+      ],
+      "post": [
+      ]
+    }
+  ],
+  "resources": [],
+  "response_templates": {
+    "DEFAULT" : {
+      "*/*" : {
+        "status" : 450,
+        "headers" : {
+          "Content-Type" : "application/xml"
+        },
+        "body" : "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<auth>\n    <resp>\n        <hdr>E</hdr>\n        <errDesc>internal technical error </errDesc>\n    </resp>\n</auth>"
+      }
+    }
+  }
+}

--- a/src/test/resources/apis/api.json
+++ b/src/test/resources/apis/api.json
@@ -1,0 +1,53 @@
+{
+  "id": "api-fail-response-template",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Javascript",
+          "description": "",
+          "enabled": true,
+          "policy": "javascript",
+          "configuration": {
+            "onRequestScript": "request.headers.set('X-Gravitee-Javascript', 'Yes');"
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Javascript",
+          "description": "",
+          "enabled": true,
+          "policy": "javascript",
+          "configuration": {
+            "onResponseScript": "response.headers.remove('X-To-Remove')"
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1759

**Description**

- Update versions to match 3.18.x+
- Add a `key` field to `PolicyResult` allowing the user to select a Response Template 
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.3.0-apim-1759-groovy-failure-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-javascript/1.3.0-apim-1759-groovy-failure-SNAPSHOT/gravitee-policy-javascript-1.3.0-apim-1759-groovy-failure-SNAPSHOT.zip)
  <!-- Version placeholder end -->
