### PR TITLE
feat: enable policy for v4 proxy API

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "3"
+
+env:
+    APIM_GW_DISTRIBUTION_PATH: "{{.APIM_GW_DISTRIBUTION_PATH }}"
+    APIM_MAPI_DISTRIBUTION_PATH: "{{.APIM_MAPI_DISTRIBUTION_PATH }}"
+
+tasks:
+    build:
+        desc: "Build"
+        cmds:
+            - mvn clean install -DskipTests -Dskip.validation
+
+    copy:
+        desc: "Copy policy"
+        cmds:
+            - cp target/gravitee-policy-javascript-*.zip ${APIM_GW_DISTRIBUTION_PATH}/plugins
+            - cp target/gravitee-policy-javascript-*.zip ${APIM_MAPI_DISTRIBUTION_PATH}/plugins
+
+    clean:
+        desc: "Clean"
+        cmds:
+            - rm ${APIM_GW_DISTRIBUTION_PATH}/plugins/gravitee-policy-javascript-*.zip
+            - rm ${APIM_MAPI_DISTRIBUTION_PATH}/plugins/gravitee-policy-javascript-*.zip

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.javascript.JavascriptPolicy
 type=policy
 category=others
 icon=javascript.svg
+proxy=REQUEST,RESPONSE

--- a/src/main/resources/schemas/policy-schema-form.json
+++ b/src/main/resources/schemas/policy-schema-form.json
@@ -9,7 +9,8 @@
       "enum" : [ "REQUEST", "RESPONSE"],
       "x-schema-form": {
         "hidden": true
-      }
+      },
+      "deprecated": true
     },
     "onRequestScript" : {
       "title": "On-request script",
@@ -32,6 +33,13 @@
             }
           }
         ]
+      },
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "context.flowPhase": ["REQUEST"]
+          }
+        }
       }
     },
     "onResponseScript" : {
@@ -55,6 +63,13 @@
             }
           }
         ]
+      },
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "context.flowPhase": ["RESPONSE"]
+          }
+        }
       }
     },
     "onRequestContentScript" : {
@@ -78,7 +93,8 @@
             }
           }
         ]
-      }
+      },
+      "deprecated": true
     },
     "onResponseContentScript" : {
       "title": "On-response content script",
@@ -101,7 +117,8 @@
             }
           }
         ]
-      }
+      },
+      "deprecated": true
     }
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9186

**Description**

Update the manifest to use the policy on V4 proxy

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-enable-policy-for-v4-proxy-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-javascript/1.4.0-enable-policy-for-v4-proxy-SNAPSHOT/gravitee-policy-javascript-1.4.0-enable-policy-for-v4-proxy-SNAPSHOT.zip)
  <!-- Version placeholder end -->
