### PR TITLE
fix: sonatype plugin update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Override central-publishing-maven-plugin to version 0.9.0 to resolve Sonatype artifact push issue -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
**Description**

Override central-publishing-maven-plugin with 0.9.0 version to overcome sonatype artifact push issue.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-sonatype-plugin-update-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-javascript/2.0.0-sonatype-plugin-update-SNAPSHOT/gravitee-policy-javascript-2.0.0-sonatype-plugin-update-SNAPSHOT.zip)
  <!-- Version placeholder end -->
